### PR TITLE
Catch errors errors and emit on stream

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,15 @@ var bpb = function () {
 		chunks.push(buffer.toString('utf8'));
 		next();
 	}, function (next) {
-		this.push(transform(chunks.join(''), options));
+		var transformed;
+		try {
+			transformed = transform(chunks.join(''), options);
+		}
+		catch (err) {
+			return next(err)
+		}
+
+		this.push(transformed)
 		next()
 	});
 };

--- a/tests/index.js
+++ b/tests/index.js
@@ -69,6 +69,19 @@ test('includes the right occurrences in es6 code', getTest({
     }
 ]));
 
+test('emit error on syntax error', function(t) {
+    t.plan(1);
+    concat('{')
+        .pipe(bpb())
+        .on("error", function(err) {
+            t.ok(err);
+            t.end();
+        })
+        .pipe(concat(function(data) {
+            t.ok(false);
+        }));
+});
+
 function getTest(){
     var options = (arguments[0] instanceof Array ? null : arguments[0]) || {};
     var test_cases = arguments[0] instanceof Array ? arguments[0] : arguments[1];


### PR DESCRIPTION
When I have a syntax error in a source file, acorn (called via falafel called via bpb) throws a sync error that cannot be caught. According to substack, browserify expects transform streams to emit errors as an "error" even on the transform stream, not throw.

> parshap> substack: i'm using a transform function that throws. how can I catch that error where I call `.bundle()`?
> substack> I don't think you can
> substack> transforms should emit errors, not throw

This changes the transform function to catch errors and emit them as the "error" event and adds a test for this behavior.
